### PR TITLE
Do not expand unset variables

### DIFF
--- a/src/file.bash
+++ b/src/file.bash
@@ -41,8 +41,8 @@
 assert_exist() {
   local -r file="$1"
   if [[ ! -e "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file or directory does not exist' \
       | fail
@@ -65,8 +65,8 @@ assert_exist() {
 assert_file_exist() {
   local -r file="$1"
   if [[ ! -f "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file does not exist' \
       | fail
@@ -89,8 +89,8 @@ assert_file_exist() {
 assert_dir_exist() {
   local -r file="$1"
   if [[ ! -d "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'directory does not exist' \
       | fail
@@ -113,8 +113,8 @@ assert_dir_exist() {
 assert_block_exist() {
   local -r file="$1"
   if [[ ! -b "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'block special file does not exist' \
       | fail
@@ -137,8 +137,8 @@ assert_block_exist() {
 assert_character_exist() {
   local -r file="$1"
   if [[ ! -c "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'character special file does not exist' \
       | fail
@@ -161,8 +161,8 @@ assert_character_exist() {
 assert_link_exist() {
   local -r file="$1"
   if [[ ! -L "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'symbolic link does not exist' \
       | fail
@@ -185,8 +185,8 @@ assert_link_exist() {
 assert_socket_exist() {
   local -r file="$1"
   if [[ ! -S "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'socket does not exist' \
       | fail
@@ -209,8 +209,8 @@ assert_socket_exist() {
 assert_fifo_exist() {
   local -r file="$1"
   if [[ ! -p "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'fifo does not exist' \
       | fail
@@ -233,8 +233,8 @@ assert_fifo_exist() {
 assert_file_executable() {
   local -r file="$1"
   if [[ ! -x "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file is not executable' \
       | fail
@@ -259,8 +259,8 @@ assert_files_equal() {
   local -r file1="$1"
   local -r file2="$2"
   if ! `cmp -s "$file1" "$file2"` ; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file1/$rem/$add}" 'path' "${file2/$rem/$add}" \
       | batslib_decorate 'files are not the same' \
       | fail
@@ -287,8 +287,8 @@ assert_file_owner() {
   sudo chown root ${TEST_FIXTURE_ROOT}/dir/owner
   sudo chown daemon ${TEST_FIXTURE_ROOT}/dir/notowner
   if [ `stat -f '%Su' "$file"` != "$owner" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "user $owner is not the owner of the file" \
       | fail
@@ -297,8 +297,8 @@ elif [[ `uname` == "Linux" ]]; then
   sudo chown root ${TEST_FIXTURE_ROOT}/dir/owner
   sudo chown daemon ${TEST_FIXTURE_ROOT}/dir/notowner
   if [ `stat -c "%U" "$file"` != "$owner" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "user $owner is not the owner of the file" \
       | fail
@@ -324,16 +324,16 @@ assert_file_permission() {
   local -r file="$2"
   if [[ `uname` == "Darwin" ]]; then
   if [ `stat -f '%A' "$file"` -ne "$permission" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "file does not have permissions $permission" \
       | fail
   fi
   elif [[ `uname` == "Linux" ]]; then
   if [ `stat -c "%a" "$file"` -ne "$permission" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "file does not have permissions $permission" \
       | fail
@@ -360,8 +360,8 @@ assert_size_zero() {
     if [[ `uname` == "Darwin" ]]; then
     mkfile 2k ${TEST_FIXTURE_ROOT}/dir/notzerobyte
     if [ -s "$file" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file is greater than 0 byte' \
       | fail
@@ -369,8 +369,8 @@ assert_size_zero() {
     elif [[ `uname` == "Linux" ]]; then
     fallocate -l 2k ${TEST_FIXTURE_ROOT}/dir/notzerobyte
     if [ -s "$file" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file is greater than 0 byte' \
       | fail
@@ -394,8 +394,8 @@ fi
 assert_file_group_id_set() {
   local -r file="$1"
   if [[ ! -g "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'set-group-ID is not set' \
       | fail
@@ -418,8 +418,8 @@ assert_file_group_id_set() {
 assert_file_user_id_set() {
   local -r file="$1"
   if [[ ! -u "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'set-user-ID is not set' \
       | fail
@@ -442,8 +442,8 @@ assert_file_user_id_set() {
 assert_sticky_bit() {
   local -r file="$1"
   if [[ ! -k "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'stickybit is not set' \
       | fail
@@ -465,16 +465,16 @@ assert_symlink_to() {
   # If OS is linux
   if [[ `uname` == "Linux" ]]; then
     if [ ! -L $link   ]; then
-      local -r rem="$BATSLIB_FILE_PATH_REM"
-      local -r add="$BATSLIB_FILE_PATH_ADD"
+      local -r rem="${BATSLIB_FILE_PATH_REM-}"
+      local -r add="${BATSLIB_FILE_PATH_ADD-}"
       batslib_print_kv_single 4 'path' "${link/$rem/$add}" \
         | batslib_decorate 'file is not a symbolic link' \
         | fail
     fi
     local -r realsource=$( readlink -f "$link" )
     if [ ! "$realsource" = "$sourcefile"  ]; then
-      local -r rem="$BATSLIB_FILE_PATH_REM"
-      local -r add="$BATSLIB_FILE_PATH_ADD"
+      local -r rem="${BATSLIB_FILE_PATH_REM-}"
+      local -r add="${BATSLIB_FILE_PATH_ADD-}"
       batslib_print_kv_single 4 'path' "${link/$rem/$add}" \
         | batslib_decorate 'symbolic link does not have the correct target' \
         | fail
@@ -500,16 +500,16 @@ assert_symlink_to() {
   }
 
   if [ ! -L $link   ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${link/$rem/$add}" \
       | batslib_decorate 'file is not a symbolic link' \
       | fail
     fi
     local -r realsource=$( readlinkf "$link" )
     if [ ! "$realsource" = "$sourcefile"  ]; then
-      local -r rem="$BATSLIB_FILE_PATH_REM"
-      local -r add="$BATSLIB_FILE_PATH_ADD"
+      local -r rem="${BATSLIB_FILE_PATH_REM-}"
+      local -r add="${BATSLIB_FILE_PATH_ADD-}"
       batslib_print_kv_single 4 'path' "${link/$rem/$add}" \
       | batslib_decorate 'symbolic link does not have the correct target' \
       | fail
@@ -534,8 +534,8 @@ assert_file_size_equals() {
   local -r expectedsize="$2"
   local -r size=$( wc -c "$file" | awk '{print $1}' )
   if [ ! "$expectedsize" = "$size" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file size does not match expected size' \
       | fail
@@ -559,8 +559,8 @@ assert_file_contains() {
   local -r file="$1"
   local -r regex="$2"
   if ! grep -q "$regex" "$file"; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file does not contain regex' \
       | fail
@@ -582,8 +582,8 @@ assert_file_contains() {
 assert_file_empty() {
   local -r file="$1"
   if [[ -s "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     { local -ir width=8
       batslib_print_kv_single "$width" 'path' "${file/$rem/$add}"
       batslib_print_kv_single_or_multi "$width" \
@@ -608,8 +608,8 @@ assert_file_empty() {
 assert_not_exist() {
   local -r file="$1"
   if [[ -e "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file or directory exists, but it was expected to be absent' \
       | fail
@@ -632,8 +632,8 @@ assert_not_exist() {
 assert_file_not_exist() {
   local -r file="$1"
   if [[ -f "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file exists, but it was expected to be absent' \
       | fail
@@ -656,8 +656,8 @@ assert_file_not_exist() {
 assert_dir_not_exist() {
   local -r file="$1"
   if [[ -d "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'directory exists, but it was expected to be absent' \
       | fail
@@ -680,8 +680,8 @@ assert_dir_not_exist() {
 assert_block_not_exist() {
   local -r file="$1"
   if [[ -b "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'block special file exists, but it was expected to be absent' \
       | fail
@@ -704,8 +704,8 @@ assert_block_not_exist() {
 assert_character_not_exist() {
   local -r file="$1"
   if [[ -c "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'character special file exists, but it was expected to be absent' \
       | fail
@@ -728,8 +728,8 @@ assert_character_not_exist() {
 assert_link_not_exist() {
   local -r file="$1"
   if [[ -L "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'symbolic link exists, but it was expected to be absent' \
       | fail
@@ -752,8 +752,8 @@ assert_link_not_exist() {
 assert_socket_not_exist() {
   local -r file="$1"
   if [[ -S "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'socket exists, but it was expected to be absent' \
       | fail
@@ -776,8 +776,8 @@ assert_socket_not_exist() {
 assert_fifo_not_exist() {
   local -r file="$1"
   if [[ -p "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'fifo exists, but it was expected to be absent' \
       | fail
@@ -800,8 +800,8 @@ assert_fifo_not_exist() {
 assert_file_not_executable() {
   local -r file="$1"
   if [[ -x "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file is executable, but it was expected to be not executable' \
       | fail
@@ -828,8 +828,8 @@ assert_not_file_owner() {
   sudo chown root ${TEST_FIXTURE_ROOT}/dir/owner
   sudo chown daemon ${TEST_FIXTURE_ROOT}/dir/notowner
   if [ `stat -f '%Su' "$file"` = "$owner" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "given user is the $owner, but it was expected not to be" \
       | fail
@@ -838,8 +838,8 @@ assert_not_file_owner() {
   sudo chown root ${TEST_FIXTURE_ROOT}/dir/owner
   sudo chown daemon ${TEST_FIXTURE_ROOT}/dir/notowner
     if [ `stat -c "%U" "$file"` = "$owner" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "given user is the $owner, but it was expected not to be" \
       | fail
@@ -865,16 +865,16 @@ assert_not_file_permission() {
   local -r file="$2"
   if [[ `uname` == "Darwin" ]]; then
     if [ `stat -f '%A' "$file"` -eq "$permission" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "file has permissions $permission, but it was expected not to have" \
       | fail
   fi
   elif [[ `uname` == "Linux" ]]; then
         if [ `stat -c "%a" "$file"` -eq "$permission" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate "file has permissions $permission, but it was expected not to have" \
       | fail
@@ -895,8 +895,8 @@ assert_files_not_equal() {
   local -r file1="$1"
   local -r file2="$2"
   if `cmp -s "$file1" "$file2"` ; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file1/$rem/$add}" 'path' "${file2/$rem/$add}" \
       | batslib_decorate 'files are the same' \
       | fail
@@ -921,8 +921,8 @@ assert_size_not_zero() {
   if [[ `uname` == "Darwin" ]]; then
   mkfile 2k ${TEST_FIXTURE_ROOT}/dir/notzerobyte
   if [[ ! -s "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file is 0 byte, but it was expected not to be' \
       | fail
@@ -930,8 +930,8 @@ assert_size_not_zero() {
   elif [[ `uname` == "Linux" ]]; then
   fallocate -l 2k ${TEST_FIXTURE_ROOT}/dir/notzerobyte
   if [[ ! -s "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file is 0 byte, but it was expected not to be' \
       | fail
@@ -956,8 +956,8 @@ fi
 assert_file_not_group_id_set() {
   local -r file="$1"
   if [ -g "$file" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'group id is set, but it was expected not to be' \
       | fail
@@ -981,8 +981,8 @@ assert_file_not_group_id_set() {
 assert_file_not_user_id_set() {
   local -r file="$1"
   if [ -u "$file" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'user id is set, but it was expected not to be' \
       | fail
@@ -1005,8 +1005,8 @@ assert_file_not_user_id_set() {
 assert_no_sticky_bit() {
   local -r file="$1"
   if [ -k "$file" ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'stickybit is set, but it was expected not to be' \
       | fail
@@ -1028,8 +1028,8 @@ assert_not_symlink_to() {
   # If OS is linux
   if [[ `uname` == "Linux" ]]; then
     if [ -L $link   ]; then
-      local -r rem="$BATSLIB_FILE_PATH_REM"
-      local -r add="$BATSLIB_FILE_PATH_ADD"
+      local -r rem="${BATSLIB_FILE_PATH_REM-}"
+      local -r add="${BATSLIB_FILE_PATH_ADD-}"
       batslib_print_kv_single 4 'path' "${link/$rem/$add}" \
         | batslib_decorate 'file is a symbolic link' \
         | fail
@@ -1061,8 +1061,8 @@ assert_not_symlink_to() {
   }
 
   if [ -L $link   ]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${link/$rem/$add}" \
       | batslib_decorate 'file is a symbolic link' \
       | fail
@@ -1091,8 +1091,8 @@ assert_not_symlink_to() {
 assert_file_not_empty() {
   local -r file="$1"
   if [[ ! -s "$file" ]]; then
-    local -r rem="$BATSLIB_FILE_PATH_REM"
-    local -r add="$BATSLIB_FILE_PATH_ADD"
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
       | batslib_decorate 'file empty, but it was expected to contain something' \
       | fail

--- a/src/temp.bash
+++ b/src/temp.bash
@@ -152,9 +152,9 @@ temp_del() {
   local -r path="$1"
 
   # Environment variables.
-  if [[ $BATSLIB_TEMP_PRESERVE == '1' ]]; then
+  if [[ ${BATSLIB_TEMP_PRESERVE-} == '1' ]]; then
     return 0
-  elif [[ $BATSLIB_TEMP_PRESERVE_ON_FAILURE == '1' ]]; then
+  elif [[ ${BATSLIB_TEMP_PRESERVE_ON_FAILURE-} == '1' ]]; then
     # Check caller.
     if ! batslib_is_caller --indirect 'teardown'; then
       echo "Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" \
@@ -163,7 +163,7 @@ temp_del() {
       return $?
     fi
 
-    (( BATS_TEST_COMPLETED != 1 )) && return 0
+    (( ${BATS_TEST_COMPLETED:-0} != 1 )) && return 0
   fi
 
   # Delete directory.

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -16,6 +16,9 @@ fixtures() {
 export TEST_MAIN_DIR="${BATS_TEST_DIRNAME}/.."
 export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/..}"
 
+# validate that bats-file is safe to use under -u
+set -u
+
 # Load dependencies.
 load "${TEST_DEPS_DIR}/bats-support/load.bash"
 # Load library.


### PR DESCRIPTION
Use `${BATSLIB_FILE_PATH_REM-}` instead of `$BATSLIB_FILE_PATH_REM`.

Use `set -u` in all tests to avoid regressions.